### PR TITLE
404 redirect for Github Pages

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <script>
+    sessionStorage.redirect = location.pathname;
+  </script>
+  <meta http-equiv="refresh" content="0;URL='/llllll-sample-bandstar'"></meta>
+</head>
+<body>
+  redirect...
+</body>
+</html>

--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import { BrowserRouter, Switch, Route } from 'react-router-dom'
 import './App.css'
 import Web3Provider from './providers/Web3Provider'
+import GithubPagesRedirectProvider from './providers/GithubPagesRedirectProvider'
 import ShareTokenDetail from './views/ShareTokenDetail'
 import TokenDetail from './views/TokenDetail'
 import MyPage from './views/MyPage'
@@ -13,15 +14,17 @@ class App extends Component {
     return (
       <Web3Provider>
         <BrowserRouter basename={'/llllll-sample-bandstar'}>
-          <React.Fragment>
-            <Header />
-            <Switch>
-              <Route exact path="/:networkName/tokens/:tokenId" component={ShareTokenDetail} />
-              <Route exact path="/tokens/:tokenId" component={TokenDetail} />
-              <Route exact path="/" component={MyPage} />
-              <Route component={NotFound} />
-            </Switch>
-          </React.Fragment>
+          <GithubPagesRedirectProvider>
+            <React.Fragment>
+              <Header />
+              <Switch>
+                <Route exact path="/:networkName/tokens/:tokenId" component={ShareTokenDetail} />
+                <Route exact path="/tokens/:tokenId" component={TokenDetail} />
+                <Route exact path="/" component={MyPage} />
+                <Route component={NotFound} />
+              </Switch>
+            </React.Fragment>
+          </GithubPagesRedirectProvider>
         </BrowserRouter>
       </Web3Provider>
     )

--- a/src/providers/GithubPagesRedirectProvider/index.js
+++ b/src/providers/GithubPagesRedirectProvider/index.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import { withRouter } from 'react-router'
+
+class GithubPagesRedirectProvider extends React.Component {
+  componentDidMount() {
+    const pathName = window.sessionStorage.redirect
+    window.sessionStorage.redirect = null
+    console.log(pathName)
+    if (pathName !== 'null') {
+      this.props.history.push(pathName)
+    }
+  }
+
+  render() {
+    return React.cloneElement(React.Children.only(this.props.children), {...this.props});
+  }
+}
+
+export default withRouter(GithubPagesRedirectProvider)


### PR DESCRIPTION
### Why

direct url is 404.
so, 404.html save location.pathname, provider push at DidMount.